### PR TITLE
Resolved Can't locate path with vendor:publish

### DIFF
--- a/src/Way/Generators/GeneratorsServiceProvider.php
+++ b/src/Way/Generators/GeneratorsServiceProvider.php
@@ -27,7 +27,7 @@ class GeneratorsServiceProvider extends ServiceProvider {
     {
         // If you need to override the default config, copy config/config.php to /config/generators.config.php and update
         $this->publishes([
-            __DIR__.'/../config/config.php' => config_path('generators.config.php'),
+            __DIR__.'../../config/config.php' => config_path('generators.config.php'),
         ]);
     }
 


### PR DESCRIPTION
fixed:  php artisan vendor:publish

message: Can't locate path </var/www/html/vendor/way/generators/src/Way/Generators/../config/config.php>